### PR TITLE
Add ARP cache table reader for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 golang library for looking up MAC address by IP address. It currently supports
 different methods for retrieving the ARP cache from the system depending if running
-on Linux or OSX. 
+on Linux, OSX or Windows. 
 
 I've only tested this library on OSX and Linux. 
 
-For Linux, `/proc/net/arp` is used. For OSX (or other unix systems), `exec.Command` is
-used to call the `arp` utility and parse its output. 
+For Linux, `/proc/net/arp` is used. For OSX (or other unix systems) and Windows,
+`exec.Command` is used to call the `arp` utility and parse its output. 
 

--- a/arp_unix.go
+++ b/arp_unix.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!windows
 
 // only tested on OSX
 // decided to go with exec.Command after I couldn't figure

--- a/arp_windows.go
+++ b/arp_windows.go
@@ -1,0 +1,49 @@
+// +build windows
+
+package arp
+
+// Windows arp table reader added by Claudio Matsuoka.
+// Tested only in Windows 8.1, hopefully the arp command output format
+// is the same in other Windows versions.
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func Table() ArpTable {
+	data, err := exec.Command("arp", "-a").Output()
+	if err != nil {
+		return nil
+	}
+
+	var table = make(ArpTable)
+	skipNext := false
+	for _, line := range strings.Split(string(data), "\n") {
+		// skip empty lines
+		if len(line) <= 0 {
+			continue
+		}
+		// skip Interface: lines
+		if line[0] != ' ' {
+			skipNext = true
+			continue
+		}
+		// skip column headers
+		if skipNext {
+			skipNext = false
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		ip := fields[0]
+		// Normalize MAC address to colon-separated format
+		table[ip] = strings.Replace(fields[1], "-", ":", -1)
+	}
+
+	return table
+}


### PR DESCRIPTION
Add a Windows-specific arp.Table function definition, using exec.Command to run the Windows arp utility. This was tested on WIndows 8.1 only. Disclaimer: I do most of my work on Linux and MacOS X and I'm not a highly skilled Windows developer. Support to Windows ARP cache table was added to be able to build a tool using this package on Windows :)
