### PR TITLE
hide terminal window on windows platform

### DIFF
--- a/arp_windows.go
+++ b/arp_windows.go
@@ -9,10 +9,13 @@ package arp
 import (
 	"os/exec"
 	"strings"
+	"syscall"
 )
 
 func Table() ArpTable {
-	data, err := exec.Command("arp", "-a").Output()
+	cmd := exec.Command("arp", "-a")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	data, err := cmd.Output()
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
This commit hides the appearing terminal window when run on Windows.

fixes #8 